### PR TITLE
feat(repository-metadata) : Ajout fichier de métadonnées .repo/metadata.yaml

### DIFF
--- a/.repo/metadata.yaml
+++ b/.repo/metadata.yaml
@@ -1,0 +1,2 @@
+organization:
+  owners: DOPSI_INF_INF


### PR DESCRIPTION
Ajout du fichier .repo/metadata.yaml qui décrit certaines métadonnées du dépôt.

  La variable owners doit correspondre au nom du ou des équipes comme renseigné dans l'organisation UTech. Par exemple pour l'équipe Architecture Logicielle, c'est DET_AL
  La valeur a été initialisée en fonction de la structure existante sur Jenkins.
  Si la valeur est <OWNER_TO_REPLACE>, cela signifie que le ou les équipes n'ont pas réussi à être déterminée et que vous devez la renseigner.

  Dans tous les cas, vous devez vérifier que l'information est correcte.
  A tout moment, il vous est possible de modifier cette valeur directement dans le fichier .repo/metadata.yaml.
  